### PR TITLE
Add Arch Linux installation instructions

### DIFF
--- a/StepManiaEditor/docs/Installation.md
+++ b/StepManiaEditor/docs/Installation.md
@@ -18,6 +18,17 @@
     ```
 3. When complete you can delete the `tar.gz` file and the extracted contents.
 
+### Arch Linux
+
+You can install via the AUR with `paru`
+```sh
+paru -S grooveauthor-bin
+```
+or `yay`
+```sh
+yay -S grooveauthor-bin
+```
+
 ## MacOS
 
 `GrooveAuthor` requires MacOS 11.0 or greater.

--- a/StepManiaEditor/docs/Installation.md
+++ b/StepManiaEditor/docs/Installation.md
@@ -20,6 +20,9 @@
 
 ### Arch Linux
 
+> [!WARNING]
+> The AUR is maintained by third parties, and packages may be out-of-date.
+
 You can install via the AUR with `paru`
 ```sh
 paru -S grooveauthor-bin
@@ -28,7 +31,6 @@ or `yay`
 ```sh
 yay -S grooveauthor-bin
 ```
-
 ## MacOS
 
 `GrooveAuthor` requires MacOS 11.0 or greater.


### PR DESCRIPTION
I added a PKGBUILD to the AUR so Arch Linux users can install the app via the package manager here: https://aur.archlinux.org/packages/grooveauthor-bin

It is essentially a modified version of the install script for Arch, that allows the package manager to be aware of the install, and handles dependencies like .net.

This is just a PR to add installation instructions for Arch users.