### PR TITLE
macOS: Use Ctrl+Q rather than Alt+F4 to quit

### DIFF
--- a/StepManiaEditor/Preferences/PreferencesKeyBinds.cs
+++ b/StepManiaEditor/Preferences/PreferencesKeyBinds.cs
@@ -173,6 +173,7 @@ internal sealed class PreferencesKeyBinds : Notifier<PreferencesKeyBinds>
 	private static readonly List<Keys[]> DefaultNew                                  = [[Ctrl, Keys.N]];
 	private static readonly List<Keys[]> DefaultReload                               = [[Ctrl, Keys.R]];
 	private static readonly List<Keys[]> DefaultClose                                = [[Ctrl, Keys.LeftShift, Keys.F4], [Ctrl, Keys.LeftShift, Keys.W]];
+	private static readonly List<Keys[]> DefaultExit                                 = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? [[Ctrl, Keys.Q]] : [[Keys.LeftAlt, Keys.F4]];
 	private static readonly List<Keys[]> DefaultUndo                                 = [[Ctrl, Keys.Z]];
 	private static readonly List<Keys[]> DefaultRedo                                 = [[Ctrl, Keys.LeftShift, Keys.Z], [Ctrl, Keys.Y]];
 	private static readonly List<Keys[]> DefaultSelectRowRange                       = [[Keys.Tab]];
@@ -449,6 +450,19 @@ internal sealed class PreferencesKeyBinds : Notifier<PreferencesKeyBinds>
 	}
 
 	private List<Keys[]> CloseInternal = DefaultClose;
+
+	[JsonInclude]
+	public List<Keys[]> Exit
+	{
+		get => ExitInternal;
+		set
+		{
+			ExitInternal = value;
+			Notify(NotificationKeyBindingChanged, this, nameof(Exit));
+		}
+	}
+
+	private List<Keys[]> ExitInternal = DefaultExit;
 
 	[JsonInclude]
 	public List<Keys[]> Undo


### PR DESCRIPTION
Alt+F4 might be captured by macOS - on my non-Apple keyboard it opens the System Settings "Display" pane - so this commit would allow using Ctrl+Q to quit on macOS.

I do not know if this commit aligns with the project's coding philosophy, so feel free to edit or refactor my commit as desired.